### PR TITLE
Add support for missing gitconfig and user section.

### DIFF
--- a/lib/gas.rb
+++ b/lib/gas.rb
@@ -19,8 +19,13 @@ module Gas
   # Shows the current user
   def self.show
     user = @gitconfig.current_user
-    puts 'Current user:'
-    puts "#{user.name} <#{user.email}>"
+
+    if user
+      puts 'Current user:'
+      puts "#{user.name} <#{user.email}>"
+    else
+      puts 'No current user in gitconfig'
+    end
   end
 
   # Sets _nickname_ as current user

--- a/spec/gas/gitconfig_spec.rb
+++ b/spec/gas/gitconfig_spec.rb
@@ -9,12 +9,17 @@ describe Gas::Gitconfig do
     @email = 'fredrik.wallgren@gmail.com'
     gitconfig = "[other stuff]\n  foo = bar\n\n[user]\n  name = #{@name}\n  email = #{@email}\n\n[foo]\n  bar = foo"
     @gitconfig = Gas::Gitconfig.new gitconfig
+    @empty_gitconfig = Gas::Gitconfig.new ''
   end
 
   it 'should be able to get current user from gitconfig' do
     user = @gitconfig.current_user
     user.name.should == @name
     user.email.should == @email
+  end
+
+  it 'should return nil if no current user is present in gitconfig' do
+    @empty_gitconfig.current_user.should == nil
   end
 
   it 'should be able to change the current user' do
@@ -25,5 +30,27 @@ describe Gas::Gitconfig do
     user = @gitconfig.current_user
     user.name.should == name
     user.email.should == email
+  end
+
+  it 'should add a new user if no user section exists in gitconfig' do
+    name = 'Test Testsson'
+    email = 'test@testsson.com'
+    @empty_gitconfig.change_user name, email
+
+    user = @empty_gitconfig.current_user
+    user.name.should == name
+    user.email.should == email
+  end
+
+  it 'should not blow up if no gitconfig exists (use empty string instead)' do
+    # Stub out File#exists?
+    class File
+      def self.exists?(path)
+        false
+      end
+    end
+
+    gitconfig_file_absent = Gas::Gitconfig.new
+    gitconfig_file_absent.instance_variable_get(:@gitconfig).should == ''
   end
 end


### PR DESCRIPTION
This commit makes it possible to use gas when:
- No [user] section is present
- No .gitconfig is present
